### PR TITLE
Fix link to OpenAI API Key in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Spaghettify is a Visual Studio Code extension that uses the power of AI to make 
 
 ## How to Use
 
-First, run the `Spaghettify - Setup` command. This will prompt you for an [OpenAI API Key](beta.openai.com/). Input your API key.
+First, run the `Spaghettify - Setup` command. This will prompt you for an [OpenAI API Key](https://openai.com/api/). Input your API key.
 
 Highlight the code you want to Spaghettify and run any of the Spaghettify magic brushes to automagically make your code worse. It's that easy!


### PR DESCRIPTION
Updates the link to the OpenAI API Key.

<img width="70%" alt="Screenshot 2023-02-23 at 11 26 58 PM" src="https://user-images.githubusercontent.com/8586063/220952227-38c0649f-7a35-407a-992a-d91c6b345dd7.png">